### PR TITLE
feat(education): add BTS Technico-commercial (2016) & Bac Pro Electrotechnique (2014) + i18n sync

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -52,10 +52,10 @@ const About: React.FC = () => {
             <h3 className="text-2xl font-semibold mb-6">{t('about.educationTitle')}</h3>
             <ul className="space-y-4">
               {t('about.education', { returnObjects: true })
-                .map((edu: { school: string; location: string; degree: string; dates: string }) => (
+                .map((edu: { school: string; location: string; degree: string; period: string }) => (
                   <li key={edu.school} className="border-b border-gray-300 dark:border-gray-800 pb-3">
                     <p className="font-medium">{edu.school} - {edu.location}</p>
-                    <p className="text-gray-500 dark:text-gray-400 text-sm">{edu.degree} ({edu.dates})</p>
+                    <p className="text-gray-500 dark:text-gray-400 text-sm">{edu.degree} ({edu.period})</p>
                   </li>
                 ))}
             </ul>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -33,16 +33,28 @@
     "educationTitle": "Education",
     "education": [
       {
-        "school": "Duke Language School",
-        "location": "Bangkok, Thailand",
-        "degree": "English Language Student",
-        "dates": "May 2025 – Sep 2025"
+        "school": "Patong & Duke Language Schools",
+        "location": "Thailand",
+        "degree": "English Diploma",
+        "period": "2024 – 2025"
       },
       {
         "school": "Le Wagon",
         "location": "Paris, France",
         "degree": "Web Development Bootcamp",
-        "dates": "Jan 2023 – Jul 2023"
+        "period": "2023"
+      },
+      {
+        "school": "Lycée Parc de Vilgénis",
+        "location": "Massy, France",
+        "degree": "BTS in Technical Sales",
+        "period": "2016"
+      },
+      {
+        "school": "Lycée Léonard de Vinci",
+        "location": "Saint-Michel-sur-Orge, France",
+        "degree": "Vocational Baccalaureate in Electrotechnics",
+        "period": "2014"
       }
     ]
   },

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -33,16 +33,28 @@
     "educationTitle": "Formation",
     "education": [
       {
-        "school": "Duke Language School",
-        "location": "Bangkok, Thaïlande",
-        "degree": "Étudiant en anglais",
-        "dates": "Mai 2025 – Sep 2025"
+        "school": "Patong & Duke Language Schools",
+        "location": "Thaïlande",
+        "degree": "Diplôme en anglais",
+        "period": "2024 – 2025"
       },
       {
         "school": "Le Wagon",
         "location": "Paris, France",
         "degree": "Bootcamp Développeur Web",
-        "dates": "Jan 2023 – Jul 2023"
+        "period": "2023"
+      },
+      {
+        "school": "Lycée Parc de Vilgénis",
+        "location": "Massy, France",
+        "degree": "BTS Technico-commercial",
+        "period": "2016"
+      },
+      {
+        "school": "Lycée Léonard de Vinci",
+        "location": "Saint-Michel-sur-Orge, France",
+        "degree": "Bac Pro Électrotechnique",
+        "period": "2014"
       }
     ]
   },


### PR DESCRIPTION
## Summary
- extend education lists with two earlier degrees and merge language schools
- rename education fields to `period` and render dynamically

## Testing
- `npm ci` *(fails: The `npm ci` command can only install with an existing package-lock.json or npm-shrinkwrap.json with lockfileVersion >= 1)*
- `npm install --no-audit --no-fund` *(fails: process terminated)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a85323e2ec833193e6aba1234b6416