### PR TITLE
feat(projects): add externalUrl on project titles with external-link icon + a11y

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,62 +1,78 @@
 import React from 'react';
-import { ArrowUpRight } from 'lucide-react';
+import { ArrowUpRight, ExternalLink as ExternalLinkIcon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Project } from '../data/projects';
+import { getCurrentLang } from '../utils/getCurrentLang';
 
-export interface ProjectCardProps {
-  title: string;
-  description: string[];
-  image: string;
-  tags: string[];
-  link?: string;
-}
+type Props = { project: Project };
 
-const ProjectCard: React.FC<ProjectCardProps> = ({
-  title,
-  description,
-  image,
-  tags,
-  link,
-}) => (
-  <div className="group rounded-lg overflow-hidden border border-gray-300 dark:border-gray-700 bg-white dark:bg-darker transform transition-transform hover:scale-105">
-    <div className="relative">
-      {link && (
-        <a
-          href={link}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label={title}
-          className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
-        >
-          <ArrowUpRight size={20} />
-        </a>
-      )}
-      <img
-        src={image}
-        alt={`${title} ${tags.slice(0, 2).join(' ')} project`}
-        loading="lazy"
-        width={1080}
-        height={720}
-        className="w-full h-48 object-cover rounded-t-lg transition-transform duration-500 ease-out group-hover:scale-105"
-      />
-    </div>
-    <div className="p-4">
-      <h3 className="font-bold text-lg mb-2">{title}</h3>
-      <ul className="list-disc list-inside text-gray-700 dark:text-gray-400 mb-3">
-        {description.map((line, idx) => (
-          <li key={idx}>{line}</li>
-        ))}
-      </ul>
-      <div className="flex flex-wrap gap-2">
-        {tags.map((tag, idx) => (
-          <span
-            key={idx}
-            className="text-xs px-3 py-1 border border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 rounded"
+const ProjectCard: React.FC<Props> = ({ project }) => {
+  useTranslation();
+  const lang = getCurrentLang();
+
+  return (
+    <div className="group/card rounded-lg overflow-hidden border border-gray-300 dark:border-gray-700 bg-white dark:bg-darker transform transition-transform hover:scale-105">
+      <div className="relative">
+        {project.externalUrl && (
+          <a
+            href={project.externalUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={project.title[lang]}
+            className="absolute top-2 right-2 opacity-0 group-hover/card:opacity-100 transition-opacity"
           >
-            {tag}
-          </span>
-        ))}
+            <ArrowUpRight size={20} />
+          </a>
+        )}
+        <img
+          src={project.image}
+          alt={`${project.title[lang]} ${project.tags.slice(0, 2).join(' ')} project`}
+          loading="lazy"
+          width={1080}
+          height={720}
+          className="w-full h-48 object-cover rounded-t-lg transition-transform duration-500 ease-out group-hover/card:scale-105"
+        />
+      </div>
+      <div className="p-4">
+        <h3 className="font-bold text-lg mb-2">
+          {project.externalUrl ? (
+            <a
+              href={project.externalUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`Ouvrir ${project.title[lang]} dans un nouvel onglet`}
+              className="inline-flex items-center gap-1 group hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/40 transition"
+            >
+              <span>{project.title[lang]}</span>
+              <ExternalLinkIcon
+                className="h-4 w-4 opacity-70 group-hover:opacity-100 translate-y-[1px] transition-transform duration-150 group-hover:translate-x-[1px]"
+                aria-hidden="true"
+              />
+              <span className="sr-only">(lien externe)</span>
+            </a>
+          ) : (
+            <span>{project.title[lang]}</span>
+          )}
+        </h3>
+        <ul className="list-disc list-inside text-gray-700 dark:text-gray-400 mb-3">
+          {project.description[lang].map((line, idx) => (
+            <li key={idx}>{line}</li>
+          ))}
+        </ul>
+        <div className="flex flex-wrap gap-2">
+          {project.tags.map((tag, idx) => (
+            <span
+              key={idx}
+              className="text-xs px-3 py-1 border border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 rounded"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default ProjectCard;
+

--- a/src/components/ProjectCardsGrid.tsx
+++ b/src/components/ProjectCardsGrid.tsx
@@ -1,27 +1,13 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import ProjectCard from './ProjectCard';
 import { projects } from '../data/projects';
-import { getCurrentLang } from '../utils/getCurrentLang';
 
-const ProjectCardsGrid: React.FC = () => {
-  useTranslation();
-  const lang = getCurrentLang();
-
-  return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-      {projects.map((project) => (
-        <ProjectCard
-          key={project.id}
-          title={project.title[lang]}
-          description={project.description[lang]}
-          image={project.image}
-          tags={project.tags}
-          link={project.url}
-        />
-      ))}
-    </div>
-  );
-};
+const ProjectCardsGrid: React.FC = () => (
+  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+    {projects.map((project) => (
+      <ProjectCard key={project.id} project={project} />
+    ))}
+  </div>
+);
 
 export default ProjectCardsGrid;

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -11,6 +11,7 @@ export interface Project {
   image: string;
   tags: string[];
   url?: string;
+  externalUrl?: string;
 }
 
 export const projects: Project[] = [
@@ -47,6 +48,7 @@ export const projects: Project[] = [
     },
     image: 'https://images.pexels.com/photos/6693638/pexels-photo-6693638.jpeg',
     tags: ['SaaS', 'E-commerce', 'Automation', 'IT'],
+    externalUrl: 'https://www.krglobalsolutionsltd.com/',
   },
   {
     id: 'felizbella',
@@ -87,6 +89,7 @@ export const projects: Project[] = [
     },
     image: 'https://images.pexels.com/photos/21273694/pexels-photo-21273694.jpeg',
     tags: ['Real Estate', 'Airbnb', 'Automation', 'Invest'],
+    externalUrl: 'https://khh-global-projects.vercel.app/',
   },
   {
     id: 'domaine',


### PR DESCRIPTION
## Summary
- add optional `externalUrl` to project data
- display project title as external link with icon when `externalUrl` exists
- simplify project card grid to pass project objects directly

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a854ea3ac48331b3a956af69856150