### PR TITLE
fix(seo): force title 'Karim Hammouche' + globe favicon from Flaticon CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,13 @@
 <html lang="fr" dir="ltr">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' ry='12' fill='black'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-family='Inter, Arial, sans-serif' font-size='34' fill='white' font-weight='700'%3EKH%3C/text%3E%3C/svg%3E" />
-    <link rel="alternate icon" type="image/png" href="https://fav.farm/⚑.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Karim Hammouche</title>
+    <link
+      rel="icon"
+      type="image/png"
+      href="https://cdn-icons-png.flaticon.com/512/921/921439.png"
+    />
 
     <!-- Initialisation du thème -->
     <script>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ const initGA = (id: string) => {
 const HomePage = () => (
   <main>
     <>
-      <SEO titleKey="seo.home.title" descriptionKey="seo.home.description" />
+      <SEO descriptionKey="seo.home.description" />
       <StructuredSEO />
     </>
     <Hero />

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router-dom'
 
 interface SEOProps {
-  titleKey?: string
   descriptionKey?: string
   image?: string
   url?: string
@@ -14,7 +13,6 @@ interface SEOProps {
 const SITE_URL = 'https://karimhammouche.com'
 
 const SEO: React.FC<SEOProps> = ({
-  titleKey,
   descriptionKey,
   image = '/vite.svg',
   url,
@@ -28,7 +26,7 @@ const SEO: React.FC<SEOProps> = ({
   const frUrl = `${baseUrl}?lang=fr`
   const enUrl = `${baseUrl}?lang=en`
 
-  const title = titleKey ? t(titleKey) : 'Karim Hammouche – Portfolio'
+  const title = 'Karim Hammouche'
   const description = descriptionKey
     ? t(descriptionKey)
     : 'Portfolio de Karim Hammouche, développeur créatif et entrepreneur.'


### PR DESCRIPTION
## Summary
- force constant "Karim Hammouche" title and use Flaticon globe favicon in `index.html`
- drop SEO titleKey usage and default to constant title

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a863ccbc4c8331978e99c485a2f03d